### PR TITLE
Support enhancement of interface types.

### DIFF
--- a/src/main/java/uk/co/blackpepper/support/reflect/AnnotationAccessor.java
+++ b/src/main/java/uk/co/blackpepper/support/reflect/AnnotationAccessor.java
@@ -71,8 +71,15 @@ public final class AnnotationAccessor {
 	
 	private static <T> T enhance(Class<T> clazz, MethodInterceptor interceptor) {
 		Enhancer enhancer = new Enhancer();
-		enhancer.setSuperclass(clazz);
-		enhancer.setInterfaces(new Class<?>[] {InvocationInfo.class});
+		
+		if (clazz.isInterface()) {
+			enhancer.setInterfaces(new Class<?>[] {InvocationInfo.class, clazz});
+		}
+		else {
+			enhancer.setInterfaces(new Class<?>[] {InvocationInfo.class});
+			enhancer.setSuperclass(clazz);
+		}
+
 		enhancer.setCallbackType(MethodInterceptor.class);
 		
 		Factory factory = (Factory) new ObjenesisStd(true).newInstance(enhancer.createClass());

--- a/src/test/java/uk/co/blackpepper/support/reflect/AnnotationAccessorTest.java
+++ b/src/test/java/uk/co/blackpepper/support/reflect/AnnotationAccessorTest.java
@@ -53,8 +53,19 @@ public class AnnotationAccessorTest {
 		}
 	}
 	
+	public static class TestInterfaceReturnTypeClass {
+		
+		public TestInterfaceReturnType method() {
+			return null;
+		}
+	}
+	
 	public static class TestReturnType {
 		// simple return type
+	}
+	
+	public interface TestInterfaceReturnType {
+		// interface return type
 	}
 	
 	private ExpectedException thrown = ExpectedException.none();
@@ -93,6 +104,16 @@ public class AnnotationAccessorTest {
 	@Test
 	public void onWithClassThenMethodReturnsInvocationInfo() {
 		assertThat(on(TestClass.class).noAnnotation(), is(instanceOf(InvocationInfo.class)));
+	}
+	
+	@Test
+	public void onWithClassThenMethodReturningInterfaceReturnsInstance() {
+		assertThat(on(TestInterfaceReturnTypeClass.class).method(), is(instanceOf(TestInterfaceReturnType.class)));
+	}
+	
+	@Test
+	public void onWithClassThenMethodReturningInterfaceReturnsInvocationInfo() {
+		assertThat(on(TestInterfaceReturnTypeClass.class).method(), is(instanceOf(InvocationInfo.class)));
 	}
 	
 	@Test


### PR DESCRIPTION
Allows AnnotationAccessor to be used to retrieve the annotations on a
method with an interface return type.

It hasn't been possible until now to retrieve annotations on methods that return interface types. You would expect to get a runtime exception of the form

`java.lang.ClassCastException: uk.co.blackpepper.support.reflect.AnnotationAccessor$InvocationInfo$$EnhancerByCGLIB$$19a491cd cannot be cast to java.util.List
    at pkg.clazz$$EnhancerByCGLIB$$ab8a796a.method(<generated>)
    at ...`

This PR fixes this.
